### PR TITLE
Dynamic wakeword audio filtering

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/service/BackgroundTask.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/service/BackgroundTask.kt
@@ -335,6 +335,13 @@ internal class BackgroundTaskController (private val context: Context): EventLis
                 WakeWordModel(name = wakeWordInfo.name, modelPath = wakeWordInfo.fileName, builtIn = wakeWordInfo.builtIn, threshold = config.wakeWordThreshold)
             )
             Timber.i("Starting wake word detection with params: $models")
+            firebase.logEvent(
+                FirebaseManager.WAKE_WORD_DETECTED, mapOf(
+                    "wake_word" to config.wakeWord,
+                    "threshold" to config.wakeWordThreshold.toString(),
+                    "prediction" to detection.score.toString()
+                )
+            )
             wakeWordEngine = WakeWordEngine(
                 context = context,
                 models = models,

--- a/app/src/main/java/com/msp1974/vacompanion/service/BackgroundTask.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/service/BackgroundTask.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Context.NOTIFICATION_SERVICE
 import android.content.res.AssetManager
 import android.media.AudioManager
-import androidx.lifecycle.viewModelScope
 import com.msp1974.vacompanion.wyoming.Zeroconf
 import com.msp1974.vacompanion.audio.AudioDSP
 import com.msp1974.vacompanion.audio.AudioManager as AudManager
@@ -19,7 +18,6 @@ import com.msp1974.vacompanion.utils.Event
 import com.msp1974.vacompanion.utils.EventListener
 import com.msp1974.vacompanion.utils.FirebaseManager
 import com.msp1974.vacompanion.utils.Helpers
-import com.msp1974.vacompanion.utils.ScreenUtils
 import com.msp1974.vacompanion.utils.WakeWords
 import com.msp1974.vacompanion.wyoming.WyomingCallback
 import com.msp1974.vacompanion.wyoming.WyomingTCPServer
@@ -55,6 +53,8 @@ internal class BackgroundTaskController (private val context: Context): EventLis
     private var holdDetectionLevelJob: Job? = null
     private var detectionScoreMonitorJob: Job? = null
     private var lastWakeWordDetectionScore = 0f
+    private var audioGateJob: Job? = null
+    private var isAudioGateOpen = false
 
 
     val zeroConf: Zeroconf = Zeroconf(context)
@@ -249,10 +249,20 @@ internal class BackgroundTaskController (private val context: Context): EventLis
                                 }
 
                                 AudioRouteOption.DETECT -> {
+                                    audioLevel = audioBuffer.max()
+
+                                    if (audioLevel > 0.005f) { // volume threshold
+                                        isAudioGateOpen = true
+                                        audioGateJob?.cancel()
+                                        audioGateJob = scope.launch {
+                                            delay(1000L) // gate duration
+                                            isAudioGateOpen = false
+                                        }
+                                    }
+
                                     if (wakeWordEngine != null) wakeWordEngine!!.processAudio(
                                         audioBuffer
                                     )
-                                    audioLevel = audioBuffer.max()
                                 }
 
                                 AudioRouteOption.STREAM -> {
@@ -348,17 +358,18 @@ internal class BackgroundTaskController (private val context: Context): EventLis
                         config.eventBroadcaster.notifyEvent(Event("screenWake", "", ""))
                     }
 
-                    if (config.wakeWordSound != "none") {
-                        WakeWordSoundPlayer(
-                            context,
-                            context.resources.getIdentifier(
-                                config.wakeWordSound,
-                                "raw",
-                                context.packageName
-                            )
-                        ).play()
+                        if (config.wakeWordSound != "none") {
+                            WakeWordSoundPlayer(
+                                context,
+                                context.resources.getIdentifier(
+                                    config.wakeWordSound,
+                                    "raw",
+                                    context.packageName
+                                )
+                            ).play()
+                        }
+                        BroadcastSender.sendBroadcast(context, BroadcastSender.WAKE_WORD_DETECTED)
                     }
-                    BroadcastSender.sendBroadcast(context, BroadcastSender.WAKE_WORD_DETECTED)
                 }
             }
             detectionScoreMonitorJob = scope.launch {
@@ -367,7 +378,6 @@ internal class BackgroundTaskController (private val context: Context): EventLis
                 }
             }
         }
-    }
 
     private fun holdLastDetectionLevel(detectionLevel: Float, duration: Long = 2000) {
         if (detectionLevel > lastWakeWordDetectionScore) {

--- a/app/src/main/java/com/msp1974/vacompanion/service/BackgroundTask.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/service/BackgroundTask.kt
@@ -335,13 +335,6 @@ internal class BackgroundTaskController (private val context: Context): EventLis
                 WakeWordModel(name = wakeWordInfo.name, modelPath = wakeWordInfo.fileName, builtIn = wakeWordInfo.builtIn, threshold = config.wakeWordThreshold)
             )
             Timber.i("Starting wake word detection with params: $models")
-            firebase.logEvent(
-                FirebaseManager.WAKE_WORD_DETECTED, mapOf(
-                    "wake_word" to config.wakeWord,
-                    "threshold" to config.wakeWordThreshold.toString(),
-                    "prediction" to detection.score.toString()
-                )
-            )
             wakeWordEngine = WakeWordEngine(
                 context = context,
                 models = models,
@@ -356,6 +349,13 @@ internal class BackgroundTaskController (private val context: Context): EventLis
                 wakeWordEngine?.detections?.collect { detection ->
                     if (isAudioGateOpen) {
                         Timber.i("${detection.model.name} wake word detected at ${detection.score}, theshold is ${config.wakeWordThreshold}")
+                        firebase.logEvent(
+                            FirebaseManager.WAKE_WORD_DETECTED, mapOf(
+                                "wake_word" to config.wakeWord,
+                                "threshold" to config.wakeWordThreshold.toString(),
+                                "prediction" to detection.score.toString()
+                            )
+                        )
 
                         // if wake up on ww, send event
                         if (config.screenOnWakeWord) {

--- a/app/src/main/java/com/msp1974/vacompanion/service/BackgroundTask.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/service/BackgroundTask.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Context.NOTIFICATION_SERVICE
 import android.content.res.AssetManager
 import android.media.AudioManager
+import androidx.lifecycle.viewModelScope
 import com.msp1974.vacompanion.wyoming.Zeroconf
 import com.msp1974.vacompanion.audio.AudioDSP
 import com.msp1974.vacompanion.audio.AudioManager as AudManager
@@ -18,6 +19,7 @@ import com.msp1974.vacompanion.utils.Event
 import com.msp1974.vacompanion.utils.EventListener
 import com.msp1974.vacompanion.utils.FirebaseManager
 import com.msp1974.vacompanion.utils.Helpers
+import com.msp1974.vacompanion.utils.ScreenUtils
 import com.msp1974.vacompanion.utils.WakeWords
 import com.msp1974.vacompanion.wyoming.WyomingCallback
 import com.msp1974.vacompanion.wyoming.WyomingTCPServer
@@ -251,7 +253,7 @@ internal class BackgroundTaskController (private val context: Context): EventLis
                                 AudioRouteOption.DETECT -> {
                                     audioLevel = audioBuffer.max()
 
-                                    if (audioLevel > 0.005f) { // volume threshold
+                                    if (audioLevel > config.wakeWordVolumeThreshold) { // volume threshold
                                         isAudioGateOpen = true
                                         audioGateJob?.cancel()
                                         audioGateJob = scope.launch {
@@ -345,18 +347,13 @@ internal class BackgroundTaskController (private val context: Context): EventLis
 
             wakeWordJob = scope.launch {
                 wakeWordEngine?.detections?.collect { detection ->
-                    Timber.i("${detection.model.name} wake word detected at ${detection.score}, theshold is ${config.wakeWordThreshold}")
-                    firebase.logEvent(
-                        FirebaseManager.WAKE_WORD_DETECTED, mapOf(
-                            "wake_word" to config.wakeWord,
-                            "threshold" to config.wakeWordThreshold.toString(),
-                            "prediction" to detection.score.toString()
-                        )
-                    )
-                    // if wake up on ww, send event
-                    if (config.screenOnWakeWord) {
-                        config.eventBroadcaster.notifyEvent(Event("screenWake", "", ""))
-                    }
+                    if (isAudioGateOpen) {
+                        Timber.i("${detection.model.name} wake word detected at ${detection.score}, theshold is ${config.wakeWordThreshold}")
+
+                        // if wake up on ww, send event
+                        if (config.screenOnWakeWord) {
+                            config.eventBroadcaster.notifyEvent(Event("screenWake", "", ""))
+                        }
 
                         if (config.wakeWordSound != "none") {
                             WakeWordSoundPlayer(
@@ -369,6 +366,8 @@ internal class BackgroundTaskController (private val context: Context): EventLis
                             ).play()
                         }
                         BroadcastSender.sendBroadcast(context, BroadcastSender.WAKE_WORD_DETECTED)
+                    } else {
+                        Timber.d("Wake word detected but audio gate was closed (score: ${detection.score})")
                     }
                 }
             }
@@ -378,6 +377,7 @@ internal class BackgroundTaskController (private val context: Context): EventLis
                 }
             }
         }
+    }
 
     private fun holdLastDetectionLevel(detectionLevel: Float, duration: Long = 2000) {
         if (detectionLevel > lastWakeWordDetectionScore) {

--- a/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
@@ -85,6 +85,10 @@ class APPConfig(val context: Context) {
         onValueChangedListener(property, oldValue, newValue)
     }
 
+    var wakeWordVolumeThreshold: Float by Delegates.observable(DEFAULT_WAKE_WORD_VOLUME_THRESHOLD) { property, oldValue, newValue ->
+        onValueChangedListener(property, oldValue, newValue)
+    }
+
     var continueConversation: Boolean by Delegates.observable(true) { property, oldValue, newValue ->
         onValueChangedListener(property, oldValue, newValue)
     }
@@ -254,6 +258,11 @@ class APPConfig(val context: Context) {
         if (settings.has("wake_word_threshold")) {
             wakeWordThreshold = settings.getInt("wake_word_threshold").toFloat() / 10
         }
+        if (settings.has("wake_word_volume_threshold")) {
+            val sensitivity = settings.getInt("wake_word_volume_threshold")
+            // Converts from 1-100 scale to 0.1 - 0.001
+            wakeWordVolumeThreshold = (0.101f - (sensitivity * 0.001f))
+        }
         if (settings.has("continue_conversation")) {
             continueConversation = settings["continue_conversation"] as Boolean
         }
@@ -372,6 +381,7 @@ class APPConfig(val context: Context) {
         const val DEFAULT_WAKE_WORD = "hey_jarvis"
         const val DEFAULT_WAKE_WORD_SOUND = "none"
         const val DEFAULT_WAKE_WORD_THRESHOLD = 0.6f
+        const val DEFAULT_WAKE_WORD_VOLUME_THRESHOLD = 0.05f
         const val DEFAULT_NOTIFICATION_VOLUME = 0.5f
         const val DEFAULT_MUSIC_VOLUME = 0.8f
         const val DEFAULT_SCREEN_BRIGHTNESS = 0.5f

--- a/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
@@ -381,7 +381,7 @@ class APPConfig(val context: Context) {
         const val DEFAULT_WAKE_WORD = "hey_jarvis"
         const val DEFAULT_WAKE_WORD_SOUND = "none"
         const val DEFAULT_WAKE_WORD_THRESHOLD = 0.6f
-        const val DEFAULT_WAKE_WORD_VOLUME_THRESHOLD = 0.05f
+        const val DEFAULT_WAKE_WORD_VOLUME_THRESHOLD = 0.001f
         const val DEFAULT_NOTIFICATION_VOLUME = 0.5f
         const val DEFAULT_MUSIC_VOLUME = 0.8f
         const val DEFAULT_SCREEN_BRIGHTNESS = 0.5f


### PR DESCRIPTION
This PR implements dynamic Wakeword Audio Filtering. This allows a range to be added to home assistant with 1-100, corresponding to the audio buffer volume of 0.1 - 0.001.

One thing I noticed while testing this is at least on my two test devices, the "mic level" sensor is not very accurate. My dog barking next to the phone only registered as a "40" on the sensor, and most of the times my wake word triggered it didn't go above 0. 

In order to make this easier to debug, I would be happy to adjust that mic level logic to more directly map to this, but wanted to see what we think about this first. 