### PR TITLE
feat: implement raw proximity sensor logic and configuration for tuya…

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
@@ -92,6 +92,10 @@ class APPConfig(val context: Context) {
         onValueChangedListener(property, oldValue, newValue)
     }
 
+    var rawProximitySensorThreshold: Int by Delegates.observable(DEFAULT_RAW_PROXIMITY_THRESHOLD) { property, oldValue, newValue ->
+        onValueChangedListener(property, oldValue, newValue)
+    }
+
     var wakeWordThreshold: Float by Delegates.observable(DEFAULT_WAKE_WORD_THRESHOLD) { property, oldValue, newValue ->
         onValueChangedListener(property, oldValue, newValue)
     }
@@ -269,6 +273,9 @@ class APPConfig(val context: Context) {
         if (settings.has("wake_word_threshold")) {
             wakeWordThreshold = settings.getInt("wake_word_threshold").toFloat() / 10
         }
+        if (settings.has("raw_proximity_threshold")) {
+            rawProximitySensorThreshold = settings.getInt("raw_proximity_threshold")
+        }
         if (settings.has("continue_conversation")) {
             continueConversation = settings["continue_conversation"] as Boolean
         }
@@ -387,6 +394,7 @@ class APPConfig(val context: Context) {
         const val NAME = "VACA"
         const val SERVER_PORT = 10800
         const val DEFAULT_HA_HTTP_PORT = 8123
+        const val DEFAULT_RAW_PROXIMITY_THRESHOLD = 300
         const val DEFAULT_WAKE_WORD = "hey_jarvis"
         const val DEFAULT_WAKE_WORD_SOUND = "none"
         const val DEFAULT_WAKE_WORD_THRESHOLD = 0.6f


### PR DESCRIPTION
Hi,

I’m using a Tuya T6E panel and recently discovered this project, so I decided to try it out. Previously, I used Automagic to wake the screen based on proximity (as described here: https://www.homeautomationguy.io/blog/home-assistant-wall-panels-with-a-tuya-s6e). That approach worked correctly, but in this application the proximity‑based wake-up does not trigger.
After investigating the issue, I noticed that the current implementation expects the proximity sensor to report values close to 0.0 when an object is near. However, on the T6E panel the sensor behaves differently:
- values around 300 correspond to a distance of roughly 5–10 cm
- values above 1000 appear when my hand is very close to the sensor
It seems that this device provides raw proximity data, not normalized values. Because of this, the existing logic never detects “near” proximity on the T6E.

Best regards,
Igor