### PR TITLE
if running on Android Things, skip Device Admin permissions.

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/MainActivity.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/MainActivity.kt
@@ -853,7 +853,9 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
     }
 
     private fun checkAndRequestDeviceAdminPermission() {
-        if (!permissions.isDeviceAdmin()) {
+        val isAndroidThings = packageManager.hasSystemFeature("android.hardware.type.embedded")
+        if (isAndroidThings) log.d("Android Things device detected - skipping Device Admin request")
+        if (!isAndroidThings && !permissions.isDeviceAdmin()) {
             val intent = Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN)
             intent.putExtra(DevicePolicyManager.EXTRA_DEVICE_ADMIN, ComponentName(this, VACADeviceAdminReceiver::class.java))
             intent.putExtra(DevicePolicyManager.EXTRA_ADD_EXPLANATION, "This application requires Device Admin rights to be able to control the screen.")


### PR DESCRIPTION
The [Device Admin check in 0.9.0](https://github.com/msp1974/ViewAssistCompanionApp/commit/0f8e796e7f922d411fdec9ccfcd5051b19b42d3f) breaks the app on Android Things as Android Things does not support this API / permission.

This PR adds a check in `checkAndRequestDeviceAdminPermission` to see if the app is running on Android Things, and, if so, does _not_ request the Device Admin permission.