### PR TITLE
Auto Brightness 

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/MainActivity.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/MainActivity.kt
@@ -238,8 +238,10 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
                 setScreenSaver(true)
                 screenWake()
             } else {
-                if (config.screenBrightness <= 0.3) config.screenBrightness = 0.6f
-                screen.setScreenBrightness(window, config.screenBrightness)
+                if (!config.screenAutoBrightness) {
+                    if (config.screenBrightness <= 0.3) config.screenBrightness = 0.6f
+                    screen.setScreenBrightness(window, config.screenBrightness)
+                }
 
                 config.screenTimeout = screen.getScreenTimeout()
                 if (config.screenTimeout < 15000) config.screenTimeout = 15000
@@ -247,7 +249,9 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
                 setScreenSaver(false)
             }
         } else if (viewModel.vacaState.value.satelliteRunning) {
-            screen.setScreenBrightness(window, config.screenBrightness)
+            if (!config.screenAutoBrightness) {
+                screen.setScreenBrightness(window, config.screenBrightness)
+            }
             screen.setScreenAutoBrightness(window, config.screenAutoBrightness)
             screen.setScreenTimeout(config.screenTimeout)
             screen.setScreenAlwaysOn(window, config.screenAlwaysOn)
@@ -545,7 +549,9 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
                     }
                     "screenBrightness" -> {
                         if (screen.isScreenOn() and !viewModel.vacaState.value.screenBlank) {
-                            screen.setScreenBrightness(window, event.newValue as Float)
+                            if (!config.screenAutoBrightness) {
+                                screen.setScreenBrightness(window, event.newValue as Float)
+                            }
                         }
                     }
                     "screenTimeout" -> screen.setScreenTimeout(config.screenTimeout)
@@ -598,7 +604,9 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
             viewModel.setScreenBlank(false)
             screen.setScreenAlwaysOn(window, config.screenAlwaysOn)
             screen.setScreenAutoBrightness(window, config.screenAutoBrightness)
-            screen.setScreenBrightness(window, config.screenBrightness)
+            if (!config.screenAutoBrightness) {
+                screen.setScreenBrightness(window, config.screenBrightness)
+            }
         }
     }
 
@@ -989,4 +997,3 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
         super.onTrimMemory(level)
     }
 }
-


### PR DESCRIPTION
Hey @msp1974,

Wanted to give this a go as it's something that I've been experiencing while using your app on a daily basis. It mostly happens when I manually set the brightness to 0 for night time and then try to re-enable auto brightness in the morning.

This is related to this issue I made:
https://github.com/msp1974/ViewAssist_Companion_App/issues/174

Manual brightness always hijacks the auto brightness setting on load, foreground, etc. This change ignores the manual brightness setting if auto brightness is on so they never collide. i.e. always respect the auto brightness if it is enabled. Might of missed some cases but wanted to get your thoughts..