### PR TITLE
Fix WebView scaling by using textZoom instead of setInitialScale

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/utils/CustomWebView.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/utils/CustomWebView.kt
@@ -62,10 +62,12 @@ class CustomWebView @JvmOverloads constructor(
             mediaPlaybackRequiresUserGesture = false
             safeBrowsingEnabled = false
             mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
-            setSupportZoom(true)
-            builtInZoomControls = false
-            useWideViewPort = false
+            textZoom = 100
+            useWideViewPort = true
             loadWithOverviewMode = true
+            setSupportZoom(false)
+            builtInZoomControls = false
+            displayZoomControls = false
             cacheMode = WebSettings.LOAD_DEFAULT
 
             webChromeClient = CustomWebChromeClient(context)
@@ -124,9 +126,10 @@ class CustomWebView @JvmOverloads constructor(
     fun setZoomLevel(level: Int) {
         if (level == 0) {
             settings.useWideViewPort = true
+            settings.textZoom = 100
         } else {
             settings.useWideViewPort = false
-            setInitialScale(level)
+            settings.textZoom = level
         }
 
     }


### PR DESCRIPTION
This change addresses the issue here: https://github.com/msp1974/ViewAssist_Companion_App/issues/196

- Reworks WebView scaling to use `textZoom` instead of `setInitialScale`.
- Sets consistent defaults:
  - `settings.textZoom = 100`
  - `settings.useWideViewPort = true`
  - `settings.loadWithOverviewMode = true`
- Updates zoom-level handling so explicit zoom uses `settings.textZoom = value`.
- Improves consistent rendering/zoom behavior across devices.
