### PR TITLE
Make Firebase optional to prevent crash without google-services.json 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
-    id("com.google.gms.google-services")
+//    id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
 }
 

--- a/app/src/main/java/com/msp1974/vacompanion/MainActivity.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
     val viewModel: VAViewModel by viewModels()
 
     private val log = Logger()
-    private val firebase = FirebaseManager.getInstance()
+    private var firebaseManager: FirebaseManager? = null
 
     private lateinit var config: APPConfig
     private lateinit var webView: CustomWebView
@@ -119,6 +119,12 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
         var keepSplashScreen = true
 
         super.onCreate(savedInstanceState)
+        firebaseManager = try {
+            FirebaseManager.getInstance(this)
+        } catch (e: Exception) {
+            log.w("Firebase unavailable: ${e.message}")
+            null
+        }
         enableEdgeToEdge()
 
         splashscreen.setKeepOnScreenCondition { keepSplashScreen }
@@ -264,10 +270,10 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
 
     fun setFirebaseUserProperties() {
         val webViewVersion = DeviceCapabilitiesManager(this).getWebViewVersion()
-        firebase.setUserProperty("webview_version", webViewVersion)
-        firebase.setUserProperty("device_signature", Helpers.getDeviceName().toString())
+        firebaseManager?.setUserProperty("webview_version", webViewVersion)
+        firebaseManager?.setUserProperty("device_signature", Helpers.getDeviceName().toString())
 
-        firebase.setCustomKeys(mapOf(
+        firebaseManager?.setCustomKeys(mapOf(
             "Webview" to webViewVersion,
             "Device" to Helpers.getDeviceName().toString(),
             "UUID" to config.uuid
@@ -472,7 +478,7 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
     private suspend fun runBackgroundTasks() {
         if ( config.backgroundTaskStatus != BackgroundTaskStatus.NOT_STARTED ) {
             log.w("Background task already running.  Not starting from MainActivity")
-            firebase.logEvent(FirebaseManager.MAIN_ACTIVITY_BACKGROUND_TASK_ALREADY_RUNNING, mapOf())
+            firebaseManager?.logEvent(FirebaseManager.MAIN_ACTIVITY_BACKGROUND_TASK_ALREADY_RUNNING, mapOf())
             if (config.isRunning) {
                 viewModel.setSatelliteRunning(true)
                 webView.setZoomLevel(config.zoomLevel)
@@ -975,7 +981,7 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
         // Try and prevent the app being killed by memory manager
         if (level >= TRIM_MEMORY_UI_HIDDEN) {
             // Release memory related to UI elements, such as bitmap caches.
-            firebase.logEvent(FirebaseManager.TRIM_MEMORY_UI_HIDDEN, mapOf())
+            firebaseManager?.logEvent(FirebaseManager.TRIM_MEMORY_UI_HIDDEN, mapOf())
             Runtime.getRuntime().gc()
 
         }
@@ -983,7 +989,7 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
         if (level >= TRIM_MEMORY_BACKGROUND) {
             // Release memory related to background processing, such as by
             // closing a database connection.
-            firebase.logEvent(FirebaseManager.TRIM_MEMORY_BACKGROUND, mapOf())
+            firebaseManager?.logEvent(FirebaseManager.TRIM_MEMORY_BACKGROUND, mapOf())
             Runtime.getRuntime().gc()
         }
 

--- a/app/src/main/java/com/msp1974/vacompanion/service/BackgroundTask.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/service/BackgroundTask.kt
@@ -46,7 +46,7 @@ enum class AudioRouteOption { NONE, DETECT, PROCESS_NO_DETECT, STREAM}
 
 internal class BackgroundTaskController (private val context: Context): EventListener {
 
-    private val firebase = FirebaseManager.getInstance()
+    private val firebase = FirebaseManager.getInstance(context)
     private var config: APPConfig = APPConfig.getInstance(context)
 
     private val job = SupervisorJob()

--- a/app/src/main/java/com/msp1974/vacompanion/service/ForegroundService.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/service/ForegroundService.kt
@@ -16,13 +16,12 @@ import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
-import com.google.firebase.Firebase
-import com.google.firebase.crashlytics.crashlytics
 import com.msp1974.vacompanion.MainActivity
 import com.msp1974.vacompanion.R
 import com.msp1974.vacompanion.VACAApplication
 import com.msp1974.vacompanion.settings.APPConfig
 import com.msp1974.vacompanion.settings.BackgroundTaskStatus
+import com.msp1974.vacompanion.utils.FirebaseManager
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.Timer
@@ -31,6 +30,7 @@ import java.util.TimerTask
 
 class VAForegroundService : LifecycleService() {
     private lateinit var config: APPConfig
+    private lateinit var firebase: FirebaseManager
     private var wifiLock: WifiManager.WifiLock? = null
     private var keyguardLock: KeyguardManager.KeyguardLock? = null
     private var watchdogTimer: Timer = Timer()
@@ -49,6 +49,7 @@ class VAForegroundService : LifecycleService() {
     override fun onCreate() {
         super.onCreate()
         config = APPConfig.getInstance(this)
+        firebase = FirebaseManager.getInstance(this)
 
         // wifi lock
         val wifiManager = applicationContext.getSystemService(WIFI_SERVICE) as WifiManager
@@ -92,7 +93,7 @@ class VAForegroundService : LifecycleService() {
                         .build()
 
                 lifecycleScope.launch {
-                    Firebase.crashlytics.log("Background service starting")
+                    firebase.addToCrashLog("Background service starting")
 
                     //need core 1.12 and higher and SDK 30 and higher
                     var requires: Int = 0
@@ -124,7 +125,7 @@ class VAForegroundService : LifecycleService() {
                     } catch (ex: Exception) {
                         Timber.i("Disabling keyguard didn't work")
                         ex.printStackTrace()
-                        Firebase.crashlytics.recordException(ex)
+                        firebase.logException(ex)
                     }
 
                     backgroundTask = BackgroundTaskController(this@VAForegroundService)
@@ -151,7 +152,7 @@ class VAForegroundService : LifecycleService() {
             }
 
             Actions.STOP.toString() -> {
-                Firebase.crashlytics.log("Background service stopping")
+                firebase.addToCrashLog("Background service stopping")
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
             }
@@ -209,7 +210,7 @@ class VAForegroundService : LifecycleService() {
         } catch (ex: Exception) {
             Timber.i("Enabling keyguard didn't work")
             ex.printStackTrace()
-            Firebase.crashlytics.recordException(ex)
+            firebase.logException(ex)
         }
     }
 

--- a/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
@@ -9,10 +9,9 @@ import android.provider.Settings.Secure
 import androidx.preference.PreferenceManager
 import androidx.core.content.edit
 import com.google.android.gms.common.util.ClientLibraryUtils.getPackageInfo
-import com.google.firebase.Firebase
-import com.google.firebase.crashlytics.crashlytics
 import com.msp1974.vacompanion.utils.Event
 import com.msp1974.vacompanion.utils.EventNotifier
+import com.msp1974.vacompanion.utils.FirebaseManager
 import com.msp1974.vacompanion.utils.Logger
 import org.json.JSONObject
 import java.util.UUID
@@ -38,6 +37,7 @@ enum class PageLoadingStage {
 class APPConfig(val context: Context) {
     private val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context.applicationContext)
     private val log = Logger()
+    private val firebase = FirebaseManager.getInstance(context)
     var eventBroadcaster: EventNotifier
     private var prefListener: Unit
 
@@ -386,7 +386,7 @@ class APPConfig(val context: Context) {
         }
 
 
-        Firebase.crashlytics.log("Settings update")
+        firebase.addToCrashLog("Settings update")
     }
 
     @SuppressLint("HardwareIds")
@@ -410,14 +410,14 @@ class APPConfig(val context: Context) {
     fun onSharedPreferenceChangedListener(prefs: SharedPreferences, key: String?) {
         log.d("SharedPreference changed: $key")
         val event = Event(key.toString(), "", "")
-        Firebase.crashlytics.log("${key.toString()} changed")
+        firebase.addToCrashLog("${key.toString()} changed")
         eventBroadcaster.notifyEvent(event)
     }
 
     fun onValueChangedListener(property: KProperty<*>, oldValue: Any, newValue: Any) {
         if (oldValue != newValue) {
             val event = Event(property.name, oldValue, newValue)
-            Firebase.crashlytics.log("${property.name} changed from $oldValue to $newValue")
+            firebase.addToCrashLog("${property.name} changed from $oldValue to $newValue")
             eventBroadcaster.notifyEvent(event)
         }
     }

--- a/app/src/main/java/com/msp1974/vacompanion/utils/CustomWebViewClient.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/utils/CustomWebViewClient.kt
@@ -24,8 +24,8 @@ import androidx.core.net.toUri
 
 class CustomWebViewClient(val viewModel: VAViewModel): WebViewClientCompat()  {
     val log = Logger()
-    private val firebase = FirebaseManager.getInstance()
     val config = viewModel.config!!
+    private val firebase = FirebaseManager.getInstance(config.context)
     private val resources = viewModel.resources!!
 
     companion object {

--- a/app/src/main/java/com/msp1974/vacompanion/utils/DeviceInfo.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/utils/DeviceInfo.kt
@@ -15,8 +15,6 @@ import android.os.BatteryManager
 import android.os.Build
 import android.webkit.WebView
 import androidx.core.content.ContextCompat.getSystemService
-import com.google.firebase.Firebase
-import com.google.firebase.crashlytics.crashlytics
 import com.msp1974.vacompanion.settings.APPConfig
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.JsonObject
@@ -45,6 +43,7 @@ data class DeviceCapabilitiesData(
 class DeviceCapabilitiesManager(val context: Context) {
 
     val log = Logger()
+    private val firebase = FirebaseManager.getInstance(context)
     val config = APPConfig.getInstance(context)
 
 
@@ -151,7 +150,7 @@ class DeviceCapabilitiesManager(val context: Context) {
         } catch (e: IllegalArgumentException) {
             // This is crucial. Catches issues like "Illegal argument to HAL module"
             // if the cameraId or characteristics query is somehow malformed on a specific device.
-            Firebase.crashlytics.recordException(e)
+            firebase.logException(e)
             return false
         } catch (e: Exception) {
             // Catch other unexpected exceptions

--- a/app/src/main/java/com/msp1974/vacompanion/utils/Logger.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/utils/Logger.kt
@@ -1,10 +1,14 @@
 package com.msp1974.vacompanion.utils
 
+import android.content.Context
 import android.os.Bundle
 import android.util.Log
 import androidx.core.os.bundleOf
 import com.google.firebase.Firebase
+import com.google.firebase.FirebaseApp
+import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.analytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.crashlytics.crashlytics
 
 class Logger {
@@ -25,18 +29,64 @@ class Logger {
     }
 }
 
-class FirebaseManager {
-    private val firebaseAnalytics = Firebase.analytics
-    private val firebaseCrashlytics = Firebase.crashlytics
+class FirebaseManager private constructor(context: Context? = null) {
+    private var firebaseAnalytics: FirebaseAnalytics? = null
+    private var firebaseCrashlytics: FirebaseCrashlytics? = null
+
+    init {
+        initialiseFirebase(context)
+    }
+
+    private fun initialiseFirebase(context: Context?) {
+        if (context == null) {
+            Log.w(Logger.TAG, "Firebase context unavailable. Firebase features disabled.")
+            return
+        }
+
+        try {
+            val appContext = context.applicationContext
+            if (FirebaseApp.getApps(appContext).isEmpty()) {
+                Log.w(Logger.TAG, "FirebaseApp not initialized. Skipping Firebase setup.")
+                return
+            }
+
+            firebaseAnalytics = Firebase.analytics
+            firebaseCrashlytics = Firebase.crashlytics
+        } catch (e: Exception) {
+            Log.w(Logger.TAG, "Failed to initialize Firebase. Firebase features disabled.", e)
+            firebaseAnalytics = null
+            firebaseCrashlytics = null
+        }
+    }
 
     companion object {
         @Volatile
         private var instance: FirebaseManager? = null
 
-        fun getInstance() =
-            instance ?: synchronized(this) {
-                instance ?: FirebaseManager().also { instance = it }
+        fun getInstance(context: Context? = null): FirebaseManager {
+            instance?.let {
+                if ((it.firebaseAnalytics != null || it.firebaseCrashlytics != null) || context == null) {
+                    return it
+                }
             }
+            return synchronized(this) {
+                val existing = instance
+                if (existing != null) {
+                    if ((existing.firebaseAnalytics != null || existing.firebaseCrashlytics != null) || context == null) {
+                        existing
+                    } else {
+                        FirebaseManager(context).also { instance = it }
+                    }
+                } else {
+                    try {
+                        FirebaseManager(context).also { instance = it }
+                    } catch (e: Exception) {
+                        Log.w(Logger.TAG, "FirebaseManager fallback initialization used.", e)
+                        FirebaseManager().also { instance = it }
+                    }
+                }
+            }
+        }
 
         const val DIAGNOSTIC_POPUP_SHOWN = "diagnostic_popup_shown"
         const val WAKE_WORD_DETECTED = "wake_word_detected"
@@ -53,24 +103,24 @@ class FirebaseManager {
     fun Map<String, Any?>.toBundle(): Bundle = bundleOf(*this.toList().toTypedArray())
 
     fun setCustomKeys(keys: Map<String, Any>) {
-        keys.map {
-            firebaseCrashlytics.setCustomKey(it.key, it.value.toString())
+        keys.forEach {
+            firebaseCrashlytics?.setCustomKey(it.key, it.value.toString())
         }
     }
 
     fun logEvent(event: String, params: Map<String, String>) {
-        firebaseAnalytics.logEvent(event, params.toBundle())
+        firebaseAnalytics?.logEvent(event, params.toBundle())
     }
 
     fun setUserProperty(key: String, value: String) {
-        firebaseAnalytics.setUserProperty(key, value)
+        firebaseAnalytics?.setUserProperty(key, value)
     }
 
     fun addToCrashLog(message: String) {
-        firebaseCrashlytics.log(message)
+        firebaseCrashlytics?.log(message)
     }
 
     fun logException(exception: Exception) {
-        firebaseCrashlytics.recordException(exception)
+        firebaseCrashlytics?.recordException(exception)
     }
 }

--- a/app/src/main/java/com/msp1974/vacompanion/utils/ScreenUtils.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/utils/ScreenUtils.kt
@@ -12,13 +12,12 @@ import android.view.WindowManager
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import com.google.firebase.Firebase
-import com.google.firebase.crashlytics.crashlytics
 import com.msp1974.vacompanion.settings.APPConfig
 
 
 class ScreenUtils(val context: Context) : ContextWrapper(context) {
     var log = Logger()
+    private val firebase = FirebaseManager.getInstance(context)
     var config = APPConfig.getInstance(context)
     private var wakeLock: PowerManager.WakeLock? = null
     var initBrightness: Float = 0f
@@ -51,7 +50,7 @@ class ScreenUtils(val context: Context) : ContextWrapper(context) {
             }
         } catch (e: Exception) {
             log.e("Error setting screen brightness: $e")
-            Firebase.crashlytics.recordException(e)
+            firebase.logException(e)
         }
     }
 
@@ -119,7 +118,7 @@ class ScreenUtils(val context: Context) : ContextWrapper(context) {
             }
         } catch (e: SecurityException) {
             log.e("Error setting screen brightness mode: $e")
-            Firebase.crashlytics.recordException(e)
+            firebase.logException(e)
         }
     }
 


### PR DESCRIPTION
- This PR makes Firebase non-required so the app runs when no default `FirebaseApp` is configured.
- Adds safe Firebase initialization and null-safe usage paths via `FirebaseManager`.
- Replaces direct Crashlytics calls in config/service/utils with safe manager calls.
- Moves `MainActivity` Firebase initialization into `onCreate()` with safe fallback.
- Prevents `Default FirebaseApp is not initialized` crashes in startup and setting-change flows.
