### PR TITLE
feat(#18): signed release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,15 @@ android {
         }
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file(System.getenv("KEYSTORE_FILE") ?: "release.keystore")
+            storePassword = System.getenv("KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("KEY_ALIAS")
+            keyPassword = System.getenv("KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
         applicationVariants.all {
             this.outputs
@@ -53,7 +62,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
         }
     }
     compileOptions {


### PR DESCRIPTION
The signing config is required and should be assigned to the release config using the correct key.

On a separate note, and I can follow up with a separate PR, I think the version code must always be incremented, too. This is required for Play store or, in my case, a private play store. I'll open a new issue and we can move discussions there.

Thank you!