### PR TITLE
feat(#24) support play stores

### DIFF
--- a/.github/workflows/build-action-artifacts.yml
+++ b/.github/workflows/build-action-artifacts.yml
@@ -15,6 +15,15 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      version_bump:
+        description: "What type of release is this?"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   build:
@@ -51,9 +60,62 @@ jobs:
       - name: Run gradle tests
         run: ./gradlew test
 
-      # Set version name as env variable
-      - name: Set version name as env variable
-        run: echo "version_name=$(echo $(./gradlew -q printVersionName))" >> $GITHUB_ENV
+      # Calculate new version based on type of release from manual dispatch.
+      - name: Calculate new version
+        id: calc_version
+        run: |
+          CURRENT_VERSION=$(grep 'versionName' app/build.gradle.kts | sed 's/.*versionName = "\(.*\)"/\1/')
+          echo "Current version: $CURRENT_VERSION"
+
+          IFS='.' read -r -a version_parts <<< "$CURRENT_VERSION"
+          MAJOR="${version_parts[0]}"
+          MINOR="${version_parts[1]}"
+          PATCH="${version_parts[2]}"
+
+          if [ "${{ inputs.version_bump }}" == "major" ]; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif [ "${{ inputs.version_bump }}" == "minor" ]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+
+      # Ensure version code is incremented by 1.
+      - name: Increment version code
+        id: inc_version_code
+        run: |
+          CURRENT_VERSION_CODE=$(grep 'versionCode' app/build.gradle.kts | sed 's/.*versionCode = \([0-9]*\)/\1/')
+          NEW_VERSION_CODE=$((CURRENT_VERSION_CODE + 1))
+          echo "version_code=$NEW_VERSION_CODE" >> $GITHUB_OUTPUT
+          echo "Previous version code: $CURRENT_VERSION_CODE"
+          echo "New version code: $NEW_VERSION_CODE"
+
+      # Update build file with new version and version code prior to building.
+      - name: Update build.gradle.kts with new version
+        run: |
+          sed -i "s/versionCode = [0-9]*/versionCode = ${{ steps.inc_version_code.outputs.version_code }}/" app/build.gradle.kts
+          sed -i "s/versionName = \".*\"/versionName = \"${{ steps.calc_version.outputs.new_version }}\"/" app/build.gradle.kts
+          echo "Updated build.gradle.kts:"
+          cat app/build.gradle.kts | grep -A 2 "versionCode"
+
+      # Commit and tag with new version name/code for release.
+      - name: Commit version bump and create tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add app/build.gradle.kts
+          git commit -m "chore: bump version to ${{ steps.calc_version.outputs.new_version }} (versionCode ${{ steps.inc_version_code.outputs.version_code }})"
+          git tag -a ${{ steps.calc_version.outputs.tag }} -m "Release ${{ steps.calc_version.outputs.tag }}"
+          git push origin main
+          git push origin ${{ steps.calc_version.outputs.tag }}
 
       # Run Build Project
       - name: Build gradle project
@@ -80,8 +142,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v${{ env.version_name }}
-          name: v${{ env.version_name }}
+          tag_name: ${{ steps.calc_version.outputs.tag }}
+          name: v${{ steps.calc_version.outputs.tag }}
           files: |
             ${{ env.main_project_module }}/build/outputs/apk/debug/vaca-*.apk
             ${{ env.main_project_module }}/build/outputs/apk/release/vaca-*.apk

--- a/.github/workflows/build-action-artifacts.yml
+++ b/.github/workflows/build-action-artifacts.yml
@@ -24,6 +24,11 @@ on:
           - patch
           - minor
           - major
+      is_beta:
+        description: "Is this a beta release?"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -84,6 +89,14 @@ jobs:
           fi
 
           NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+
+          if [ "${{ inputs.is_beta }}" == "true" ]; then
+            NEW_VERSION="$NEW_VERSION-beta"
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
@@ -148,6 +161,6 @@ jobs:
             ${{ env.main_project_module }}/build/outputs/apk/debug/vaca-*.apk
             ${{ env.main_project_module }}/build/outputs/apk/release/vaca-*.apk
           draft: true
-          prerelease: false
+          prerelease: ${{ steps.calc_version.outputs.is_prerelease == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a set of improvements to the build and release workflow for the project, primarily focusing on automating version management during manual releases.

**Build and Release Workflow Automation:**

- Added manual workflow dispatch inputs (`version_bump` and `is_beta`) to `.github/workflows/build-action-artifacts.yml`, allowing users to specify the type of version bump (patch, minor, major) and whether the release is a beta.
- Automated calculation and updating of the version name and version code in `app/build.gradle.kts` based on workflow inputs, including incrementing the version code and tagging the release in Git.
- Updated the release creation step to use the new version and prerelease status dynamically, ensuring GitHub releases are correctly tagged and marked as pre-releases if applicable.

## Developer and release workflow recommendation
> Note none of this is required for this PR. More so recommendations on how to get the most out of the PR and ensure low overhead for you and contributors.

- use main branch as repo's primary target branch.
- branch features off main and PR into main (or you could simply commit to main)
- When ready to release, manually trigger workflow with release type and if its beta.
- Currently only one beta is supported at a time; can be addressed by a follow up PR to change this.

I also recommend if you need to update your feature branch with new changes from other PRs that have merged to main, to do so via `git pull --rebase origin main` on your feature branch. This will create and keep a clean and linear git history which makes troubleshooting, git bisect, reverts, etc. much more straight forward.

The reason I recommend branching off main for a feature and merging it into main via PR: run tests on PR to validate. Only merge when feature is ready. It helps keep main releasable at all/or most of the time. This is important given if this is not the case, you have to manually keep track of what commit/when main is stable enough to release. This also is the same process for external contributors.