### PR TITLE
fix: avoid Android microphone effects on known unstable Lenovo/MediaTek audio HAL devices

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/audio/MicrophoneInput.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/audio/MicrophoneInput.kt
@@ -5,6 +5,7 @@ import android.media.AudioRecord
 import android.media.audiofx.AcousticEchoCanceler
 import android.media.audiofx.AutomaticGainControl
 import android.media.audiofx.NoiseSuppressor
+import android.os.Build
 import androidx.annotation.RequiresPermission
 import com.msp1974.vacompanion.settings.APPConfig
 import timber.log.Timber
@@ -27,6 +28,10 @@ class MicrophoneInput (
 
     private var audioDSP = AudioDSP()
 
+    private val disableAndroidAudioEffects: Boolean by lazy {
+        config.disableAndroidAudioEffects || isKnownProblematicAndroidAudioEffectsDevice()
+    }
+
     private val bufferSize =
         AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat)
 
@@ -41,7 +46,11 @@ class MicrophoneInput (
         }
 
         if (!isRecording) {
-            Timber.d("Starting microphone with AGC=${agc != null}, AEC=${aec != null}, NS=${ns != null}")
+            val useSpeex = disableAndroidAudioEffects || !AutomaticGainControl.isAvailable()
+            Timber.d(
+                "Starting microphone with AndroidAudioEffectsDisabled=$disableAndroidAudioEffects, " +
+                    "AGC=${agc != null}, AEC=${aec != null}, NS=${ns != null}, Speex=$useSpeex"
+            )
             audioRecord?.startRecording()
         } else {
             Timber.w("Microphone already started")
@@ -62,7 +71,7 @@ class MicrophoneInput (
         val audioRecord = this.audioRecord ?: error("Microphone not started")
         val readCount = audioRecord.read(audioBuffer, 0, audioBuffer.size)
         if (readCount > 0) {
-            if (useSpeex && !AutomaticGainControl.isAvailable()) {
+            if (useSpeex && (disableAndroidAudioEffects || !AutomaticGainControl.isAvailable())) {
                 speex.echoSuppressionEnabled = false
                 speex.denoiseEnabled = false
                 speex.setMaxAGCGain(10f + (config.micGain * 1.95f))
@@ -98,22 +107,75 @@ class MicrophoneInput (
     }
 
     private fun setupAudioEffects() {
+        if (disableAndroidAudioEffects) {
+            agc = null
+            aec = null
+            ns = null
+            Timber.w(
+                "Android audio effects disabled for stability. " +
+                    "manufacturer=${Build.MANUFACTURER}, brand=${Build.BRAND}, model=${Build.MODEL}, " +
+                    "device=${Build.DEVICE}, product=${Build.PRODUCT}"
+            )
+            return
+        }
+
         val sessionId = audioRecord?.audioSessionId ?: return
+
         try {
             if (AutomaticGainControl.isAvailable()) {
                 agc = AutomaticGainControl.create(sessionId)
                 agc?.enabled = true
             }
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to enable Android AutomaticGainControl")
+            agc = null
+        }
+
+        try {
             if (AcousticEchoCanceler.isAvailable()) {
                 aec = AcousticEchoCanceler.create(sessionId)
                 aec?.enabled = true
             }
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to enable Android AcousticEchoCanceler")
+            aec = null
+        }
 
+        try {
             if (NoiseSuppressor.isAvailable()) {
                 ns = NoiseSuppressor.create(sessionId)
                 ns?.enabled = true
             }
-        } catch (e: Exception) {}
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to enable Android NoiseSuppressor")
+            ns = null
+        }
+    }
+
+    private fun isKnownProblematicAndroidAudioEffectsDevice(): Boolean {
+        return isLenovoTb8505fs()
+    }
+
+    private fun isLenovoTb8505fs(): Boolean {
+        val manufacturer = Build.MANUFACTURER.orEmpty().lowercase()
+        val brand = Build.BRAND.orEmpty().lowercase()
+        val model = Build.MODEL.orEmpty().lowercase()
+        val device = Build.DEVICE.orEmpty().lowercase()
+        val product = Build.PRODUCT.orEmpty().lowercase()
+        val fingerprint = Build.FINGERPRINT.orEmpty().lowercase()
+
+        val isLenovo =
+            manufacturer.contains("lenovo") ||
+                brand.contains("lenovo") ||
+                fingerprint.contains("lenovo")
+        val isTb8505fs =
+            model.contains("tb-8505fs") ||
+                device.contains("8505") ||
+                product.contains("8505") ||
+                fingerprint.contains("lenovotb-8505fs") ||
+                fingerprint.contains("8505fs")
+
+        return isLenovo && isTb8505fs
     }
 
     override fun close() {

--- a/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
@@ -88,6 +88,10 @@ class APPConfig @Inject constructor(val context: Context) {
         onValueChangedListener(property, oldValue, newValue)
     }
 
+    var disableAndroidAudioEffects: Boolean by Delegates.observable(false) { property, oldValue, newValue ->
+        onValueChangedListener(property, oldValue, newValue)
+    }
+
     var wakeWordEngine: String by Delegates.observable("openwakeword") { property, oldValue, newValue ->
         onValueChangedListener(property, oldValue, newValue)
     }
@@ -290,6 +294,7 @@ class APPConfig @Inject constructor(val context: Context) {
         settings["ha_url"]?.jsonPrimitive?.contentOrNull?.let { homeAssistantURL = it }
         settings["ha_dashboard"]?.jsonPrimitive?.contentOrNull?.let { homeAssistantDashboard = it }
         settings["advanced_gain"]?.jsonPrimitive?.booleanOrNull?.let { useAdvancedGain = it }
+        settings["disable_android_audio_effects"]?.jsonPrimitive?.booleanOrNull?.let { disableAndroidAudioEffects = it }
         settings["wake_word_engine"]?.jsonPrimitive?.contentOrNull?.let { wakeWordEngine = it }
         settings["wake_word"]?.jsonPrimitive?.contentOrNull?.let { wakeWord = it }
         settings["wake_word_sound"]?.jsonPrimitive?.contentOrNull?.let { wakeWordSound = it }


### PR DESCRIPTION
### Summary

Adds a guarded stability path for devices where Android platform microphone effects can destabilize the vendor audio HAL.

On Lenovo TB-8505FS Android 10, enabling Android AGC/AEC/NS through the microphone `AudioRecord` session appears to trigger MediaTek/Dolby audio HAL instability. The observed failure mode is the vendor audio HAL growing to roughly 495-500 MB RSS, followed by VACA dying and restarting even while it remains the foreground/top app.

This change avoids creating Android `AutomaticGainControl`, `AcousticEchoCanceler`, and `NoiseSuppressor` on known-problem Lenovo TB-8505FS devices, or when explicitly configured via `disable_android_audio_effects`.

Other devices keep the existing Android AudioEffect behavior.

### Implementation

- Adds a narrow known-device guard for Lenovo TB-8505FS.
- Adds optional config flag `disable_android_audio_effects`, defaulting to `false`.
- Skips Android AGC/AEC/NS creation when Android audio effects are disabled.
- Uses the software/Speex processing path when Android audio effects are disabled.
- Preserves existing Android AudioEffect behavior for unaffected devices.
- Adds startup logging for the selected microphone processing path.
- Adds per-effect exception handling so AGC/AEC/NS creation/enabling failures are logged independently.

### Why

The Lenovo TB-8505FS failure pattern pointed to the vendor audio effect path rather than normal app memory pressure:

- VACA remained foreground/top with `oom cur=0`.
- VACA memory was not the largest pressure source during the failure.
- `android.hardware.audio@5.0-service-mediatek` repeatedly grew to roughly 495-500 MB RSS.
- VACA then died as a foreground/top process.
- After the death/restart, the audio HAL dropped back to only a few MB RSS.
- Native crash evidence referenced MediaTek/Dolby audio effect code, including `libswdap.so` and `dms service died`.

A test build that disabled Android audio effects stopped the repeated foreground VACA deaths on the affected tablet.

### Recent validation

After applying the guarded audio-effects disable path on the affected Lenovo TB-8505FS:

- VACA remained foreground/top.
- The MediaTek audio HAL stayed low, around 9-10 MB RSS in recent samples.
- `com.dolby.daxservice` was absent from user-space processes.
- Only the native `vendor.dolby.hardware.dms@2.0-service` remained, at minimal RSS.
- No further `Process com.msp1974.vacompanion has died: fore TOP` events were observed during the validation window.

Representative post-fix sample:

```text
MemAvailable: 666212 kB
VACA TOTAL:   493773 kB
Graphics:      67526 kB

audio HAL RSS:
android.hardware.audio@5.0-service-mediatek 9668 kB

dolby/dax processes:
vendor.dolby.hardware.dms@2.0-service 904 kB

VACA process state:
oom cur=0
foregroundActivities=true
mHasForegroundServices=true
top-activity
```

Additional samples continued to show the audio HAL stable at about 9668 kB while VACA remained foreground/top.

### Testing

- Built successfully with `./gradlew assembleDebug`.
- Confirmed this branch is based directly on upstream `dev`.
- Installed and tested on Lenovo TB-8505FS Android 10.
- Reproduced the original failure before the patch.
- Confirmed the failure stopped after disabling Android audio effects on the affected device.

### Notes for maintainers

This is intentionally scoped as a guarded device/config stability path rather than a global removal of Android AudioEffects. The goal is to avoid a known unstable vendor audio-effect path on confirmed-problem devices while preserving existing behavior for unaffected devices.
