### PR TITLE
Fix brightness restore before enabling auto-brightness

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/MainActivity.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/MainActivity.kt
@@ -621,8 +621,8 @@ class MainActivity : AppCompatActivity(), EventListener, ComponentCallbacks2 {
             Timber.d("Disabling screen saver")
             viewModel.setScreenBlank(false)
             screen.setScreenAlwaysOn(window, config.screenAlwaysOn)
-            screen.setScreenAutoBrightness(window, config.screenAutoBrightness)
             screen.setScreenBrightness(window, config.screenBrightness)
+            screen.setScreenAutoBrightness(window, config.screenAutoBrightness)
         }
     }
 

--- a/app/src/main/java/com/msp1974/vacompanion/device/ScreenUtils.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/device/ScreenUtils.kt
@@ -65,6 +65,8 @@ class ScreenUtils (val context: Context, val config: APPConfig) : ContextWrapper
             setDeviceBrightnessMode(false)
             setScreenBrightness(window, config.screenBrightness)
         } else {
+            setDeviceBrightnessMode(false)
+            setScreenBrightness(window, config.screenBrightness)
             setDeviceBrightnessMode(true)
         }
     }


### PR DESCRIPTION
﻿## Summary
- restore the configured screen brightness before re-enabling Android auto-brightness
- keep screen saver wake/restore behavior from leaving Android's persisted brightness at the dim saver value

## Why
When screen saver dimming writes a very low brightness value, a later wake can restore auto-brightness before restoring the configured brightness. On devices where Android keeps that low persisted baseline, the screen can come back extremely dim even though the configured brightness is higher.

## Testing
- compiled, Installed, and tested to verified an off/on cycle with auto-brightness enabled restored the configured brightness instead of the dim saver value.
