### PR TITLE
Replace homemade Speex AGC with plain dB mic trim (fixes hard-clipped capture on devices without platform AGC)

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/audio/MicrophoneInput.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/audio/MicrophoneInput.kt
@@ -12,6 +12,7 @@ import com.msp1974.vacompanion.settings.APPConfig
 import timber.log.Timber
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import kotlin.math.pow
 
 class MicrophoneInput (
     val config: APPConfig,
@@ -64,13 +65,15 @@ class MicrophoneInput (
         val audioRecord = this.audioRecord ?: error("Microphone not started")
         val readCount = audioRecord.read(audioBuffer, 0, audioBuffer.size)
         if (readCount > 0) {
-            if (useSpeex && !AutomaticGainControl.isAvailable()) {
-                speex.echoSuppressionEnabled = false
-                speex.denoiseEnabled = false
-                speex.setMaxAGCGain(20f + (config.micGain * 1.95f))
-                return speex.processFrame(audioBuffer.copyOfRange(0, readCount))
+            val frame = audioBuffer.copyOfRange(0, readCount)
+            if (useSpeex && !AutomaticGainControl.isAvailable() && config.micGain != 0) {
+                // mic_gain is a plain dB trim (-10..+10 dB); 0 = unprocessed
+                val gain = 10.0.pow(config.micGain / 20.0).toFloat()
+                for (i in frame.indices) {
+                    frame[i] = (frame[i] * gain).toInt().coerceIn(-32768, 32767).toShort()
+                }
             }
-            return audioBuffer.copyOfRange(0, readCount)
+            return frame
         }
         return ShortArray(0)
     }


### PR DESCRIPTION
Fixes #41.

### What

Replaces the `SpeexProcessor` AGC path in `MicrophoneInput.readShort()` with a plain dB trim: `mic_gain` −10…+10 now maps to −10…+10 dB, and 0 is untouched passthrough. One file, ~10 lines.

### Why

On devices without a platform `AutomaticGainControl` effect (e.g. the Lenovo ThinkSmart View on LineageOS 15.1), the previous path applied `20 + micGain*1.95` as a **constant linear multiplier** with a hard clip — ×20 (+26 dB) at the default slider position, flat-topping 25–37% of samples in far-field captures. Full analysis with measurements in #41.

Devices that ship a platform AGC skip this branch entirely (unchanged behaviour).

### Verified

Built and deployed on a ThinkSmart View (LineageOS 15.1, armeabi-v7a): wake word + STT now work cleanly across a large room at gain 0; the slider behaves predictably as a ±10 dB trim. STT captures that previously showed 25–37% full-scale samples are clean.

### Notes

If you'd prefer to keep automatic gain here, I'm happy to rework this as a correctly-parameterised limiter (fast attack / slow release, soft knee) instead — but a predictable manual trim seemed like the safest immediate fix, and it makes the existing HA `mic_gain` entity meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfW8kEbY9X855KnT9purYc
