### PR TITLE
feat: implement enableNetworkRecovery for dynamic IP environments

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/wyoming/WyomingTCPServer.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/wyoming/WyomingTCPServer.kt
@@ -308,8 +308,13 @@ abstract class WyomingTCPServer(private val context: Context, val deviceManager:
         if (config.pairedDeviceID.isEmpty()) {
             config.pairedDeviceID = serverIP
         } else if (!isValidServer(serverIP)) {
-            Timber.e("Non paired server attempted to start satellite.  Paired to ${config.pairedDeviceID}, attempting server: $serverIP")
-            return
+            if (config.enableNetworkRecovery && !isOldPairedServerStillConnected()) {
+                Timber.i("Network recovery: accepting new server IP %s (was paired to %s)", serverIP, config.pairedDeviceID)
+                config.pairedDeviceID = serverIP
+            } else {
+                Timber.e("Non paired server attempted to start satellite.  Paired to ${config.pairedDeviceID}, attempting server: $serverIP")
+                return
+            }
         }
 
         if (satellite != null) {
@@ -375,6 +380,10 @@ abstract class WyomingTCPServer(private val context: Context, val deviceManager:
 
     private fun isValidServer(ipAddr: String): Boolean {
         return config.pairedDeviceID == "" || config.pairedDeviceID == ipAddr
+    }
+
+    private fun isOldPairedServerStillConnected(): Boolean {
+        return clients.values.any { it.handler.clientIP == config.pairedDeviceID }
     }
 
     private suspend fun stopSatellite() {


### PR DESCRIPTION
When enableNetworkRecovery is true (default) and a new server IP attempts to connect while the old paired IP is no longer connected, accept the new IP and update the pairing instead of rejecting it.

This fixes connectivity loss in environments with dynamic IPs (e.g. MAC-VLAN with DHCP) where HA container restarts cause IP changes.

Co-authored-by: AI [https://huggingface.co/zai-org/GLM-5.2]