### PR TITLE
Don't stop the Wyoming server when a client drops during connection setup

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/wyoming/WyomingTCPServer.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/wyoming/WyomingTCPServer.kt
@@ -118,63 +118,78 @@ abstract class WyomingTCPServer(private val context: Context, val deviceManager:
                         break
                     }
 
-                    val remoteAddress = runCatching { socket.remoteAddress.toString() }
-                        .getOrElse {
-                            "unknown-remote(${it::class.simpleName})"
-                        }
-                    val id = runCatching { socket.remoteAddress.port().toString() }
-                        .getOrElse {
-                            "unknown-${System.nanoTime()}"
-                        }
-
-                    val data = buildJsonObject {
-                        put("remoteId", remoteAddress)
-                    }
-
-                    val client: WyomingClientHandler = object : WyomingClientHandler(scope, socket) {
-                        override suspend fun onClientDisconnected(clientId: String) {
-
-                            if (clientId in clients) {
-                                val client = clients[clientId]
-                                client?.handler?.stop()
-                                clients.remove(clientId)
+                    // Setting up a connection must never be able to stop the server.
+                    // A peer that connects and immediately disconnects (a TCP health
+                    // check, a port scan, `nc -z`) can make the setup below throw
+                    // ClosedChannelException. That used to escape to the outer
+                    // `catch (e: Throwable)`, which runs the `finally` block and shuts
+                    // down the whole Wyoming server - taking the satellite and any
+                    // in-progress media playback with it. Contain per-client failures
+                    // here so one transient peer cannot take everything down.
+                    try {
+                        val remoteAddress = runCatching { socket.remoteAddress.toString() }
+                            .getOrElse {
+                                "unknown-remote(${it::class.simpleName})"
                             }
-                            Timber.d("Client disconnected: $clientId.  Total: ${clients.size}")
-
-                            if (clientId == satellite?.clientId) {
-                                satellite?.clientId = ""
+                        val id = runCatching { socket.remoteAddress.port().toString() }
+                            .getOrElse {
+                                "unknown-${System.nanoTime()}"
                             }
 
-                            if (clients.isEmpty()) {
-                                Timber.d("No clients connected")
-                                satellite?.clientId = ""
-                                disconnectionMonitor()
-                            }
-                            updateStatus()
+                        val data = buildJsonObject {
+                            put("remoteId", remoteAddress)
                         }
 
-                        override suspend fun onWyomingMessage(
-                            clientId: String,
-                            message: WyomingPacket
-                        ) {
-                            try {
-                                // Added to prevent processing first message before client handler correctly setup
-                                withTimeout(250.milliseconds) {
-                                    while (clientId !in clients) {
-                                        delay(10.milliseconds)
-                                    }
+                        val client: WyomingClientHandler = object : WyomingClientHandler(scope, socket) {
+                            override suspend fun onClientDisconnected(clientId: String) {
+
+                                if (clientId in clients) {
+                                    val client = clients[clientId]
+                                    client?.handler?.stop()
+                                    clients.remove(clientId)
                                 }
-                                messageHandler(clientId, message)
-                            } catch (e: Exception) {
-                                Timber.e("Error processing message: $e")
+                                Timber.d("Client disconnected: $clientId.  Total: ${clients.size}")
+
+                                if (clientId == satellite?.clientId) {
+                                    satellite?.clientId = ""
+                                }
+
+                                if (clients.isEmpty()) {
+                                    Timber.d("No clients connected")
+                                    satellite?.clientId = ""
+                                    disconnectionMonitor()
+                                }
+                                updateStatus()
+                            }
+
+                            override suspend fun onWyomingMessage(
+                                clientId: String,
+                                message: WyomingPacket
+                            ) {
+                                try {
+                                    // Added to prevent processing first message before client handler correctly setup
+                                    withTimeout(250.milliseconds) {
+                                        while (clientId !in clients) {
+                                            delay(10.milliseconds)
+                                        }
+                                    }
+                                    messageHandler(clientId, message)
+                                } catch (e: Exception) {
+                                    Timber.e("Error processing message: $e")
+                                }
                             }
                         }
-                    }
 
-                    clients[id] = Connection(id, client)
-                    Timber.d("Client connected: ${socket.remoteAddress}.  Total: ${clients.size}")
-                    updateStatus()
-                    onEvent("client_connected", data)
+                        clients[id] = Connection(id, client)
+                        Timber.d("Client connected: ${socket.remoteAddress}.  Total: ${clients.size}")
+                        updateStatus()
+                        onEvent("client_connected", data)
+                    } catch (e: Throwable) {
+                        ensureActive()
+                        Timber.w("Discarding client connection that failed during setup: $e")
+                        runCatching { socket.close() }
+                        continue
+                    }
                 }
             } catch (e: Throwable) {
                 ensureActive()


### PR DESCRIPTION
## Problem

`serverSocket?.accept()` in `WyomingTCPServer.startServer()` is already guarded against `ClosedChannelException`, but the per-connection setup that follows is not. If the peer has gone away by the time `WyomingClientHandler` is constructed, the throw escapes the `while (runServer)` loop into the outer `catch (e: Throwable)`, and the `finally` block then shuts the **whole** server down — `stopSatellite()`, every client closed, NSD unregistered.

Any peer that connects and disconnects immediately can trigger it: a TCP health check, a monitoring probe, `nc -z`, a port scan.

The user-visible symptom is that music stops mid-playback and the display jumps back to the home view, because `MusicPlayerService` is destroyed as a side effect. Notably there is **no `ExoPlaybackException`** — the player did not fail, it was released underneath:

```
13:04:55.703 D WyomingTCPServer$startServer$2$client: Client disconnected: 35347.  Total: 1
13:04:55.705 E WyomingTCPServer$startServer: Server Error: java.nio.channels.ClosedChannelException
13:04:55.705 D WyomingTCPServer$startServer: Stopping Wyoming TCP Server...
13:04:55.707 I ExoPlayerImpl: Release 5d11e6c [AndroidXMedia3/1.10.1] ...
13:04:55.730 D MusicPlayerService: Music service destroy
13:04:55.735 D MusicPlayerService: Music player: Stopping music
```

## Fix

Wrap the per-connection setup in its own `try`/`catch` and `continue` on failure, so one transient peer cannot stop the server. The socket is closed on the way out to avoid leaking it.

Behaviour for healthy clients is unchanged; the diff is mostly the re-indent from introducing the block.

## How this was found

An Echo Show 5 (LineageOS 18.1, Android 11, VACA 0.12.1) was dropping AirPlay playback from Music Assistant after a few minutes. The trigger turned out to be a Home Assistant `command_line` sensor polling `nc -z <device> 10800` once a minute for liveness. `logcat` shows the connect/disconnect pair every 60s at `:55`, and occasionally one takes the server down:

```
11:46:55.641  Client disconnected
11:46:55.643  Client connected
11:47:55.644  Client disconnected
11:47:55.652  Server Error: java.nio.channels.ClosedChannelException
11:47:55.657  Stopping Wyoming TCP Server...
```

It is a race, not deterministic — most probes are handled fine. Every playback interruption observed lined up with a probe tick, and removing the probe stopped them.

To reproduce: run `nc -z <device-ip> 10800` in a loop while music plays, and watch `logcat | grep WyomingTCPServer`.

## Testing

I do not have an Android build environment set up, so this is **compile-untested** — please treat it accordingly. The change is limited to adding a `try`/`catch`/`continue` around an existing block; `ClosedChannelException` and `ensureActive` are already imported in this file.

Full write-up, including two secondary observations (`MusicPlayerService` has no `onPlayerError` handler, and the default 8 s `DefaultHttpDataSource` read timeout is tight for realtime sources), is in the linked issue.

Issue with the full investigation: msp1974/ViewAssist_Companion_App#280