### PR TITLE
Fix external auth recovery after token refresh failures

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/device/authentication/AuthenticationManager.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/device/authentication/AuthenticationManager.kt
@@ -4,14 +4,15 @@ import androidx.core.net.toUri
 import com.msp1974.vacompanion.settings.APPConfig
 import io.ktor.client.call.body
 import io.ktor.http.isSuccess
-import timber.log.Timber
-import java.net.ConnectException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.net.URL
 
 class AuthenticationManager(
     val config: APPConfig
 ) {
     private val authenticationService = AuthenticationService()
+    private val sessionMutex = Mutex()
 
     suspend fun buildBearerToken(): String {
         ensureValidSession()
@@ -19,11 +20,24 @@ class AuthenticationManager(
     }
 
     suspend fun ensureValidSession(forceRefresh: Boolean = false) {
-        if (isExpired() || forceRefresh || config.accessToken == "") {
-            try {
+        val accessTokenBeforeLock = config.accessToken
+
+        sessionMutex.withLock {
+            // Another external-auth request may have refreshed the session while this
+            // request was waiting for the lock. In that case, reuse the new token even
+            // if both requests arrived with force=true.
+            val refreshedWhileWaiting =
+                accessTokenBeforeLock != config.accessToken && !isExpired()
+            val refreshRequired =
+                isExpired() || config.accessToken.isBlank() || (forceRefresh && !refreshedWhileWaiting)
+
+            if (refreshRequired) {
+                if (config.refreshToken.isBlank()) {
+                    throw AuthenticationException("No refresh token available", 0, null)
+                }
+                // Do not swallow refresh failures. Callers must never treat an expired
+                // access token as a successful external-auth response.
                 refreshSessionWithToken(config.refreshToken)
-            } catch (e: Exception) {
-                Timber.e("Failed to refresh token: ${e.message}")
             }
         }
     }
@@ -44,18 +58,24 @@ class AuthenticationManager(
         return authenticationService.refreshToken(
             url = getBaseUrl(),
             refreshToken = refreshToken,
-        ).let {
-            if (it.status.isSuccess()) {
-                val refreshedToken = it.body<Token>()
+        ).let { response ->
+            if (response.status.isSuccess()) {
+                val refreshedToken = response.body<Token>()
                 //TODO: Make this an object on DeviceManager session info
                 config.accessToken = refreshedToken.accessToken
                 config.tokenExpiry = System.currentTimeMillis() + (refreshedToken.expiresIn * 1000)
                 return@let
-            } else if (it.status.value == 400 && it.body<String>().contains("invalid_grant")
-            ) {
-                revokeSession()
             }
-            throw AuthenticationException("Failed to refresh token", it.status.value, it.body<String?>())
+
+            val errorBody = response.body<String?>()
+            if (response.status.value == 400 && errorBody?.contains("invalid_grant") == true) {
+                // The refresh credential is no longer usable. Clear the local session
+                // without making another request with the already-invalid token.
+                config.accessToken = ""
+                config.refreshToken = ""
+                config.tokenExpiry = 0
+            }
+            throw AuthenticationException("Failed to refresh token", response.status.value, errorBody)
         }
     }
 

--- a/app/src/main/java/com/msp1974/vacompanion/utils/CustomWebView.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/utils/CustomWebView.kt
@@ -16,7 +16,6 @@ import com.msp1974.vacompanion.jsinterface.WebAppInterface
 import com.msp1974.vacompanion.jsinterface.WebViewJavascriptInterface
 import com.msp1974.vacompanion.settings.PageLoadingStage
 import com.msp1974.vacompanion.device.DeviceManager
-import com.msp1974.vacompanion.device.authentication.AuthenticationException
 import com.msp1974.vacompanion.jsinterface.ExternalAuthCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -124,20 +123,25 @@ class CustomWebView @JvmOverloads constructor(
         }
     }
 
-    suspend fun requestAuthorisation(forceRefresh: Boolean = false) {
+    suspend fun requestAuthorisation(forceRefresh: Boolean = false, view: WebView = this) {
         try {
             if (config.refreshToken != "") {
                 deviceManager.authenticationManager.ensureValidSession(forceRefresh)
                 withContext(Dispatchers.Main) {
-                    callAuthJS()
+                    callAuthJS(view, true)
                 }
             } else {
                 withContext(Dispatchers.Main) {
-                    loadUrl(deviceManager.authenticationManager.getExternalAuthUrl())
+                    view.loadUrl(deviceManager.authenticationManager.getExternalAuthUrl())
                 }
             }
-        } catch (ex: AuthenticationException) {
-            Timber.e("Error authenticating with HA: ${ex.message}")
+        } catch (ex: Exception) {
+            Timber.e(ex, "Error authenticating with HA")
+            withContext(Dispatchers.Main) {
+                // Home Assistant's external-auth contract requires an explicit failure.
+                // Never inject the previous token after a failed refresh.
+                callAuthJS(view, false)
+            }
         }
     }
 
@@ -149,7 +153,7 @@ class CustomWebView @JvmOverloads constructor(
                 val payloadJson = json.parseToJsonElement(payload).jsonObject
                 val forceRefresh = payloadJson["force"]?.jsonPrimitive?.boolean ?: false
                 scope.launch {
-                    requestAuthorisation(forceRefresh)
+                    requestAuthorisation(forceRefresh, view)
                 }
             } else {
                 Timber.w("Requested authentication with HA while network was unavailable")
@@ -168,14 +172,16 @@ class CustomWebView @JvmOverloads constructor(
 
     }
 
-    private fun callAuthJS() {
-        evaluateJavascript(
+    private fun callAuthJS(view: WebView, success: Boolean) {
+        val script = if (success) {
             "window.externalAuthSetToken(true, {\n" +
-                    "\"access_token\": \"${config.accessToken}\",\n" +
-                    "\"expires_in\": ${((config.tokenExpiry - System.currentTimeMillis())/1000).toInt()}\n" +
-                    "});",
-            null
-        )
+                "\"access_token\": \"${config.accessToken}\",\n" +
+                "\"expires_in\": ${((config.tokenExpiry - System.currentTimeMillis()) / 1000).toInt().coerceAtLeast(0)}\n" +
+                "});"
+        } else {
+            "window.externalAuthSetToken(false);"
+        }
+        view.evaluateJavascript(script, null)
     }
 
     val ViewAssistEventHandler = object : ViewAssistCallback {

--- a/app/src/main/java/com/msp1974/vacompanion/utils/CustomWebViewClient.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/utils/CustomWebViewClient.kt
@@ -134,6 +134,25 @@ class CustomWebViewClient(val viewModel: VAViewModel): WebViewClientCompat()  {
     }
 
     override fun onPageFinished(view: WebView?, url: String?) {
+        val haBaseUrl = viewModel.deviceManager.authenticationManager
+            .getBaseUrl()
+            .toString()
+            .removeSuffix("/")
+        if (
+            view is CustomWebView &&
+            !url.isNullOrBlank() &&
+            url.startsWith(haBaseUrl, ignoreCase = true) &&
+            !url.contains("/auth/authorize") &&
+            config.accessToken.isNotBlank() &&
+            config.refreshToken.isNotBlank()
+        ) {
+            // A reconnect can replace the page while a native refresh is in flight,
+            // losing the original JavaScript callback. Re-inject the current session
+            // after the replacement page is ready.
+            viewModel.viewModelScope.launch {
+                view.requestAuthorisation()
+            }
+        }
         if (url != ERROR_URL && viewModel.vacaState.value.webViewPageLoadingStage == PageLoadingStage.AUTHORISED) {
             Handler(Looper.getMainLooper()).postDelayed({
                 setPageLoadingState(PageLoadingStage.LOADED)


### PR DESCRIPTION
## Summary

Fix Home Assistant external-auth recovery so VACA does not report success with an expired access token after a refresh failure, race concurrent refresh requests, or lose a refreshed session when the WebView page is replaced.

This addresses the long-running kiosk failure described in msp1974/ViewAssist_Companion_App#187, where VACA can remain alive and connected while Home Assistant shows an unable-to-connect page until the app is restarted.

## Root cause

- `AuthenticationManager.ensureValidSession()` swallowed refresh exceptions.
- `CustomWebView.requestAuthorisation()` then unconditionally called `externalAuthSetToken(true, ...)` with the previous token.
- Overlapping normal and forced external-auth callbacks could race duplicate refreshes.
- A reconnect navigation could replace the page while refresh was in flight, losing the original JavaScript callback.

## Changes

- Serialize refreshes with a coroutine `Mutex`; a waiter reuses a session refreshed while it was waiting.
- Propagate refresh failures instead of treating stale credentials as success.
- Clear the local session on `invalid_grant` without attempting another request with the invalid credential.
- Return Home Assistant's required `externalAuthSetToken(false)` response on failure.
- Deliver the response to the WebView that initiated the request.
- Re-inject a valid session after an authenticated HA page replacement.

## Validation

- `./gradlew test assembleDebug lint`: 113 tasks completed with no failures.
- Parallel canary package deployed on an Echo Show 5 (960x480) and Echo Show 8 (1280x800), alongside untouched stable VACA.
- 72-hour dual-device soak with two-minute package-aware health monitoring:
  - one activity and one WebView
  - HA control socket and HTTP healthy
  - no VACA teardown loop
  - physically rendered Home Assistant dashboards
  - no unmatched auth error, `invalid_grant`, or stale-success loop
- Deterministic overlapping normal + forced external-auth callbacks produced one refresh exchange; the waiting request reused the refreshed session.
- Final forced refresh on both devices completed in about 90-105 ms with a rendered authenticated dashboard afterward.
- After restoring unpatched stable 0.12.1, the known expired-token failure reproduced; switching back to this patched canary restored healthy long-running operation on both devices.

## Scope

This is intentionally focused on current `dev` authentication code. Unlike #35, it does not add token heartbeats/JWT parsing or bundle unrelated screen, Wi-Fi-lock, and sensor changes.

## Development disclosure

This fix and its testing workflow were AI-assisted. Nicholas Kreucher (`@kreucher`) reviewed the observed behavior, canary evidence, and final PR text before submission.
