### PR TITLE
Recover satellite takeover after client reconnect

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/satellite/Satellite.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/satellite/Satellite.kt
@@ -226,26 +226,40 @@ abstract class Satellite(var context: Context, val deviceManager: DeviceManager,
         )
     }
 
-    suspend fun handleSatelliteTakeover(clientId: String) {
+    fun prepareSatelliteTakeover(clientId: String) {
+        // This must run before WyomingTCPServer resumes reading the new connection.
+        // Otherwise its settings event can arrive before initSettings is reset.
+        this.clientId = clientId
         config.initSettings = false
+    }
+
+    suspend fun handleSatelliteTakeover(clientId: String) {
+        if (this.clientId != clientId) return
+
         val loadedSettings = waitForSettings(5000)
         if (!loadedSettings) {
-            // Try 1 more time in case of timing issue
+            if (this.clientId != clientId) return
+
+            // Explicitly request settings from the reconnected client
             sendSatelliteMessage(clientId, WyomingEvent.CUSTOM_EVENT, buildJsonObject {
                 put(EVENT_TYPE, WyomingCustomEventType.SETTINGS)
             })
             if (!waitForSettings(2000)) {
-                state = SatelliteState.ERROR
-                return
+                if (this.clientId != clientId) return
+
+                // Connection is live; continue with cached settings rather than
+                // wedging the satellite into ERROR just because the refresh was slow.
+                Timber.w("Settings not received after reconnect; continuing with cached settings")
             }
         }
+
+        if (this.clientId != clientId) return
 
         // Verify app version
         if (!validateAppVersion()) {
             stop()
             start()
         } else {
-            this.clientId = clientId
             BroadcastSender.sendBroadcast(context, BroadcastSender.SATELLITE_CLIENT_UPDATED)
         }
     }

--- a/app/src/main/java/com/msp1974/vacompanion/wyoming/WyomingTCPServer.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/wyoming/WyomingTCPServer.kt
@@ -330,8 +330,10 @@ abstract class WyomingTCPServer(private val context: Context, val deviceManager:
         if (satellite != null) {
             if (satellite?.state == SatelliteState.RUNNING) {
                 Timber.d("Satellite already running - updating clientId")
+                val runningSatellite = satellite ?: return
+                runningSatellite.prepareSatelliteTakeover(clientId)
                 scope.launch {
-                    satellite?.handleSatelliteTakeover(clientId)
+                    runningSatellite.handleSatelliteTakeover(clientId)
                 }
                 return
             } else if (satellite?.state == SatelliteState.STOPPING) {


### PR DESCRIPTION
## Summary

Fix reconnect takeover so a running VACA satellite can accept a replacement Home Assistant Wyoming client without losing an already-received settings event or becoming stuck on `Waiting for connection`.

This targets the reconnect failure discussed in msp1974/ViewAssist_Companion_App#138, where a device can lose its Wyoming connection and fail to recover automatically.

## Root cause

After a transport interruption, Home Assistant reconnects and sends `run-satellite` followed by settings. The previous implementation launched takeover asynchronously, allowing the settings event to arrive before takeover reset `initSettings`. The already-received settings were then discarded, while the fallback request could not be sent because the new client ID was assigned only at the end of takeover. After both waits timed out, the live satellite entered `ERROR`; VACA retained a connected Wyoming client but showed `Waiting for connection` indefinitely.

## Changes

- Prepare a running satellite takeover synchronously before the Wyoming server resumes reading the replacement client.
- Bind the replacement client ID before requesting settings so the request can be routed.
- Ignore stale takeover coroutines when a newer client has already won.
- Continue with cached settings if a live reconnected client does not return refreshed settings within the bounded wait, instead of moving the satellite permanently to `ERROR`.

## Validation

- `./gradlew test assembleDebug lint`: 113 tasks completed with no failures.
- Installed the rebased canary on two LineageOS Echo Show 8 Gen 1 devices and one Echo Show 5 Gen 1.
- Six intentionally triggered View Assist config-entry reloads exercised Wyoming disconnect/reconnect takeover on one Echo Show 8. Every cycle retained the same app PID, converged to one established TCP/10800 socket, and returned to a rendered authenticated dashboard.
- A subsequent 24-hour three-device soak retained the matching canary package and APK hash and included three observed Wi-Fi disconnect/reconnect cycles on the Echo Show 5. All three devices remained on rendered authenticated dashboards with no `Waiting for connection` state; two-minute package-aware monitoring recorded zero `connection_stuck` samples on every device.
- Rebased onto current upstream `dev` (`c69dfe8`). Exact-head validation confirmed commit `9ee25c2` is one commit ahead and zero behind, with the intended two-file +22/-6 diff and clean `git diff --check`.

## Scope

This is intentionally limited to takeover of an already-running satellite after a replacement client connects. It complements #51, which contains failures during per-connection setup, and does not claim to resolve every network or reconnect cause discussed in msp1974/ViewAssist_Companion_App#138.

## Development disclosure

This fix and its testing workflow were AI-assisted. Nicholas Kreucher (`@kreucher`) reviewed the observed behavior, canary evidence, and final PR text before submission.

