### PR TITLE
feat: add bypassBluetoothMic setting to prevent SCO audio degradation

### DIFF
--- a/app/src/main/java/com/msp1974/vacompanion/audio/MicrophoneInput.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/audio/MicrophoneInput.kt
@@ -225,8 +225,10 @@ class MicrophoneInput (
             Timber.d("MIC Device: ${device.productName}, type: ${getDeviceTypeName(device.type)}")
         }
 
+        val bypassBluetoothMic = config.bypassBluetoothMic
+
         val usbDevice = devices.firstOrNull { isUsbMic(it) }
-        val bluetoothDevice = devices.firstOrNull { isBluetoothMic(it) }
+        val bluetoothDevice = if (bypassBluetoothMic) null else devices.firstOrNull { isBluetoothMic(it) }
 
         when {
             usbDevice != null -> selectUsbDevice(currentRecord, usbDevice)

--- a/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/settings/Settings.kt
@@ -293,6 +293,10 @@ class APPConfig @Inject constructor(val context: Context) {
         get() = this.sharedPrefs.getBoolean("startOnBoot", false)
         set(value) = this.sharedPrefs.edit { putBoolean("startOnBoot", value) }
 
+    var bypassBluetoothMic: Boolean
+        get() = this.sharedPrefs.getBoolean("bypass_bluetooth_mic", false)
+        set(value) = this.sharedPrefs.edit { putBoolean("bypass_bluetooth_mic", value) }
+
     var uuid: String
         get() = this.sharedPrefs.getString("uuid", getUUID()) ?: ""
         set(value) = this.sharedPrefs.edit { putString("uuid", value) }

--- a/app/src/main/java/com/msp1974/vacompanion/ui/VAViewModel.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/ui/VAViewModel.kt
@@ -601,6 +601,23 @@ class VAViewModel @Inject constructor(
         }
     }
 
+    fun restartApp() {
+        val context = application.applicationContext
+        val intent = android.content.Intent(context, com.msp1974.vacompanion.MainActivity::class.java)
+        intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK or android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        val pendingIntent = android.app.PendingIntent.getActivity(
+            context, 0, intent,
+            android.app.PendingIntent.FLAG_CANCEL_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE
+        )
+        val mgr = context.getSystemService(Context.ALARM_SERVICE) as android.app.AlarmManager
+        mgr.set(android.app.AlarmManager.RTC, System.currentTimeMillis() + 1000, pendingIntent)
+        android.content.Intent(context, com.msp1974.vacompanion.service.VAForegroundService::class.java).also {
+            it.action = com.msp1974.vacompanion.service.VAForegroundService.Actions.STOP.toString()
+            context.startService(it)
+        }
+        Runtime.getRuntime().exit(0)
+    }
+
     fun setShowMenu(show: Boolean) {
         _vacaState.update { currentState ->
             currentState.copy(

--- a/app/src/main/java/com/msp1974/vacompanion/ui/components/AudioSettingsDialog.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/ui/components/AudioSettingsDialog.kt
@@ -1,0 +1,146 @@
+package com.msp1974.vacompanion.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.msp1974.vacompanion.ui.theme.CustomColours
+
+@Composable
+fun AudioSettingsDialog(
+    onDismissRequest: () -> Unit,
+    onConfirmation: (useBluetoothMic: Boolean) -> Unit,
+    onClose: () -> Unit,
+    initialValue: Boolean,
+    confirmText: String = "OK",
+    dismissText: String = "Cancel",
+) {
+    Dialog(
+        onDismissRequest = { onDismissRequest() },
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+            usePlatformDefaultWidth = false,
+        ),
+    ) {
+        AudioSettingsDialogContent(
+            initialValue = initialValue,
+            onDismissRequest = onDismissRequest,
+            onConfirmation = onConfirmation,
+            onClose = onClose,
+            confirmText = confirmText,
+            dismissText = dismissText
+        )
+    }
+}
+
+@Composable
+fun AudioSettingsDialogContent(
+    initialValue: Boolean,
+    onDismissRequest: () -> Unit,
+    onConfirmation: (useBluetoothMic: Boolean) -> Unit,
+    onClose: () -> Unit,
+    confirmText: String,
+    dismissText: String,
+) {
+    var useBluetoothMic by rememberSaveable { mutableStateOf(!initialValue) }
+
+    Card(
+        modifier = Modifier
+            .padding(16.dp)
+            .width(400.dp)
+            .height(320.dp),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Audio Settings",
+                fontSize = 18.sp,
+                modifier = Modifier
+                    .padding(16.dp),
+            )
+            Text(
+                text = "When using Bluetooth microphones, audio playback quality may degrade if audio output is also via Bluetooth.",
+                fontSize = 12.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(16.dp),
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Use Bluetooth Microphone",
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 16.sp,
+                    modifier = Modifier
+                        .padding(end = 16.dp)
+                )
+                Switch(
+                    checked = useBluetoothMic,
+                    onCheckedChange = { useBluetoothMic = it },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = CustomColours.GREEN,
+                    )
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxSize(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.Bottom
+            ) {
+                Button(
+                    onClick = {
+                        onDismissRequest()
+                        onClose()
+                    },
+                    modifier = Modifier.padding(8.dp),
+                ) {
+                    Text(dismissText)
+                }
+                Button(
+                    onClick = {
+                        onConfirmation(useBluetoothMic)
+                        onClose()
+                    },
+                    modifier = Modifier.padding(8.dp),
+                ) {
+                    Text(confirmText)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/msp1974/vacompanion/ui/layouts/SettingsLayout.kt
+++ b/app/src/main/java/com/msp1974/vacompanion/ui/layouts/SettingsLayout.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.filled.DisabledByDefault
 import androidx.compose.material.icons.filled.FileCopy
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Security
+import androidx.compose.material.icons.filled.SettingsVoice
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -22,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.zIndex
 import com.msp1974.vacompanion.ui.VAViewModel
+import com.msp1974.vacompanion.ui.components.AudioSettingsDialog
 import com.msp1974.vacompanion.ui.components.MenuLayout
 import com.msp1974.vacompanion.ui.components.MenuOption
 import com.msp1974.vacompanion.ui.components.UUIDEditDialog
@@ -41,7 +43,9 @@ enum class SettingsScreen {
 enum class Dialog {
     NONE,
     CLEAR_PAIRING,
-    EDIT_UUID
+    EDIT_UUID,
+    AUDIO_SETTINGS,
+    RESTART_APP
 }
 
 /**
@@ -97,6 +101,14 @@ fun SettingsLayout(
                         )
                     }
 
+                    menuOptions.add(
+                        MenuOption(
+                            title = "Audio Settings",
+                            subtitle = "Configure Bluetooth microphone usage",
+                            icon = Icons.Default.SettingsVoice,
+                            onClick = { currentDialog = Dialog.AUDIO_SETTINGS }
+                        )
+                    )
                     menuOptions.add(
                         MenuOption(
                             title = "Manage Custom Files",
@@ -182,6 +194,30 @@ fun SettingsLayout(
                         dialogTitle = "Clear Paired Device Entry",
                         dialogText = "This will delete the currently paired Home Assistant server and allow another server to connect and pair to this device.",
                         confirmText = "Confirm",
+                        dismissText = "Cancel",
+                    )
+                }
+                Dialog.AUDIO_SETTINGS -> {
+                    AudioSettingsDialog(
+                        onDismissRequest = { currentDialog = Dialog.NONE },
+                        onConfirmation = { useBluetoothMic ->
+                            viewModel.config.bypassBluetoothMic = !useBluetoothMic
+                            currentDialog = Dialog.RESTART_APP
+                        },
+                        onClose = { },
+                        initialValue = viewModel.config.bypassBluetoothMic
+                    )
+                }
+                Dialog.RESTART_APP -> {
+                    VADialog(
+                        onDismissRequest = { currentDialog = Dialog.NONE },
+                        onConfirmation = {
+                            currentDialog = Dialog.NONE
+                            viewModel.restartApp()
+                        },
+                        dialogTitle = "Restart App",
+                        dialogText = "Configuration changed. Restart VACA?",
+                        confirmText = "OK",
                         dismissText = "Cancel",
                     )
                 }


### PR DESCRIPTION
Hello,
The latest addition to my family of displays is a Lenovo M10 (TB-X606X) paired with a Lenovo dock for Alexa. I ran into an audio issue because the dock is controlled via Bluetooth (at least when connecting an X606X to the dock intended for an X606FA). When VACA uses Bluetooth for the microphone, the audio output drops to 8 kHz mono. That is why I added a switch in the app so that I don't *have* to use the Bluetooth microphone for VACA.

When a Bluetooth device advertising an HFP/SCO profile (e.g. a smart speaker dock with microphone) is connected, VACA selects it as the preferred microphone input. This activates MODE_IN_COMMUNICATION and startBluetoothSco(), which forces ALL audio output through the narrowband SCO link (8kHz mono) instead of A2DP (48kHz stereo). This degrades audio playback quality for the entire device, not just VACA.

This patch adds:
- A new "bypass_bluetooth_mic" SharedPreferences setting (default: false, no behaviour change for existing users)
- An "Audio Settings" dialog in the VACA Settings menu with a toggle to enable/disable Bluetooth microphone usage
- A restart confirmation dialog after changing the setting
- App restart via AlarmManager (analogous to AppExceptionHandler)

When enabled (toggle OFF), VACA ignores Bluetooth SCO input devices and uses the built-in microphone, preserving A2DP audio output quality.

Co-authored-by: AI [https://huggingface.co/zai-org/GLM-5.2]